### PR TITLE
Fixing issue #17 by upgrading the node version for netstats client...

### DIFF
--- a/eth-netstats/Dockerfile
+++ b/eth-netstats/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12
+FROM node:7
 
 RUN git clone https://github.com/cubedro/eth-netstats
 RUN cd /eth-netstats && npm install


### PR DESCRIPTION
Apparently one of the libraries used by the netstats client has been upgraded recently and can't deal with the old 0.12 release of node as noted by issue #17; using the latest node, version 7, fixes that issue