### PR TITLE
Geth found at /geth

### DIFF
--- a/monitored-geth-client/Dockerfile
+++ b/monitored-geth-client/Dockerfile
@@ -11,6 +11,8 @@ RUN cd /root &&\
     cd eth-net-intelligence-api &&\
     npm install &&\
     npm install -g pm2
+    
+RUN ln -sf /geth /usr/bin/geth
 
 ADD start.sh /root/start.sh
 ADD app.json /root/eth-net-intelligence-api/app.json


### PR DESCRIPTION
Geth is found at `/geth` not `/usr/bin/geth` in the `ethereum/client-go` image. The below updates the Dockerfile to provide a symlink.