### PR TITLE
Fixes for Geth 1.6.2, Alpine based Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     links:
       - netstats
     entrypoint: /root/start.sh
-    command: '--datadir=~/.ethereum/devchain --nodekeyhex=091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --ipcapi="admin,db,eth,debug,miner,net,shh,txpool,personal,web3" --rpcapi "db,personal,eth,net,web3" --rpccorsdomain="*" --networkid=456719 --rpc --rpcaddr="0.0.0.0"'
+    command: '--datadir=~/.ethereum/devchain --nodekeyhex=091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --rpcapi "db,personal,eth,net,web3" --rpccorsdomain="*" --networkid=456719 --rpc --rpcaddr="0.0.0.0"'
     volumes:
       - ./files/password:/root/files/password:ro
       - ./files/genesis.json:/root/files/genesis.json:ro

--- a/files/genesis.json
+++ b/files/genesis.json
@@ -1,11 +1,17 @@
 {
+  "config": {
+    "chainId": 0,
+    "homesteadBlock": 0,
+    "eip155Block": 0,
+    "eip158Block": 0
+  },
   "nonce": "0x0000000000000042",
   "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "difficulty": "0x400",
   "coinbase": "0x3333333333333333333333333333333333333333",
   "timestamp": "0x0",
   "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "extraData": "Custem Ethereum Genesis Block",
+  "extraData": "0x",
   "gasLimit": "0x8000000",
   "alloc": {
     "0x007ccffb7916f37f7aeef05e8096ecfbe55afc2f": {

--- a/monitored-geth-client/Dockerfile
+++ b/monitored-geth-client/Dockerfile
@@ -1,10 +1,7 @@
 FROM ethereum/client-go
 
-RUN apt-get update &&\
-    apt-get install -y curl git-core &&\
-    curl -sL https://deb.nodesource.com/setup_4.x | bash - &&\
-    apt-get update &&\
-    apt-get install -y nodejs
+RUN apk update &&\
+    apk add git nodejs bash perl
 
 RUN cd /root &&\
     git clone https://github.com/cubedro/eth-net-intelligence-api &&\


### PR DESCRIPTION
Changes necessary for latest Geth client and Ethereum's Alpine based Docker image:
- Switched from apt to apk for monitored Geth client
- Had to remove ipcapi from bootstrap entry
- Added chain config to genesis file

This should fix issue #24 