### PR TITLE
Fix chain id to match network id

### DIFF
--- a/files/genesis.json
+++ b/files/genesis.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 0,
+    "chainId": 456719,
     "homesteadBlock": 0,
     "eip155Block": 0,
     "eip158Block": 0


### PR DESCRIPTION
My pull request #25 introduced an error (sorry!): when the chain id does not match the network id, transactions fail with "invalid sender." This new pull request fixes this.