### PR TITLE
[Optimisation, n/a] update geth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ To access the Netstats Web UI:
 open http://$(docker-machine ip default):3000
 ```
 
-#### Scaling the number of nodes/containers in the cluster
+### Scaling the number of nodes/containers in the cluster
+
+You can scale the number of Ethereum nodes by running:
 
 ```
 docker-compose scale eth=3
 ```
 
-Will scale the number of Ethereum nodes upwards (replace 3 with however many nodes
+This will scale the number of Ethereum nodes **upwards** (replace 3 with however many nodes
 you prefer). These nodes will connect to the P2P network (via the bootstrap node)
 by default.
 
@@ -76,20 +78,22 @@ As part of the bootstrapping process we bootstrap 10 Ethereum accounts for use
 pre-filled with 20 Ether for use in transactions by default.
 
 If you want to change the amount of Ether for those accounts
-See ```files/genesis.json```.
+See `files/genesis.json`.
 
 ## 2. Interact with geth
 
-If you want to start mining or stop mining you need to connect to the node via:
+To get attached to the `geth` JavaScript console on the node you can run the following
 ```
 docker exec -it ethereumdocker_eth_1 geth attach ipc://root/.ethereum/devchain/geth.ipc
 ```
-Replace ethereumdocker_geth_1 with the container name you wish to connect to.
+Then you can `miner.start()`, and then check to see if it's mining by inspecting `web3.eth.mining`. 
 
-### 2.1 Use existing DAG
+See the [Javascript Runtime](https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console) docs for more.
 
-To speed up the process, you can use a pre-generated DAG. All you need to do is add something like this
+### 2.1 Use an existing DAG
+
+To speed up the process, you can use a [pre-generated DAG](https://github.com/ethereum/wiki/wiki/Ethash-DAG). All you need to do is add something like this
 ```
 ADD dag/full-R23-0000000000000000 /root/.ethash/full-R23-0000000000000000
 ```
-to the monitored-geth-client Dockerfile.
+to the `monitored-geth-client` Dockerfile.

--- a/eth-netstats/Dockerfile
+++ b/eth-netstats/Dockerfile
@@ -1,11 +1,14 @@
-FROM node:7
+FROM node:8-alpine
+
+RUN apk add --update git
 
 RUN git clone https://github.com/cubedro/eth-netstats
-RUN cd /eth-netstats && npm install
-RUN cd /eth-netstats && npm install -g grunt-cli
-RUN cd /eth-netstats && grunt
 
 WORKDIR /eth-netstats
+
+RUN npm install
+RUN npm install -g grunt-cli
+RUN grunt
 
 EXPOSE 3000
 

--- a/monitored-geth-client/Dockerfile
+++ b/monitored-geth-client/Dockerfile
@@ -1,7 +1,6 @@
-FROM ethereum/client-go:v1.6.5
+FROM ethereum/client-go
 
-RUN apk update &&\
-    apk add git nodejs bash perl
+RUN apk add --update git bash nodejs nodejs-npm perl
 
 RUN cd /root &&\
     git clone https://github.com/cubedro/eth-net-intelligence-api &&\


### PR DESCRIPTION
* I have removed the version restriction on the `ethereum/client-go` image so it will now always install the latest version.
* I have also updated the base node version in `eth-netstats` to `node:8-alpine` which is more up to date and installs faster.
* I've also updated the README slightly to be clearer.

I've tested these changes under Docker for Mac on my development machine (running High Sierra) and it works perfectly.