### PR TITLE
Mount point fix using /etc/localtime file creation and pointing to it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - ./files/password:/root/files/password:ro
       - ./files/genesis.json:/root/files/genesis.json:ro
       - ./files/keystore:/root/.ethereum/devchain/keystore:rw
-      - /etc/localtime:/etc/localtime:ro
+      - ~/etc/timezone:/etc/localtime:ro
+#      - /etc/localtime:/etc/localtime:ro
     ports:
       - "30303:30303"
       - "30303:30303/udp"
@@ -29,7 +30,8 @@ services:
       - ./files/password:/root/files/password:ro
       - ./files/genesis.json:/root/files/genesis.json:ro
       - ./files/keystore:/root/.ethereum/devchain/keystore:rw
-      - /etc/localtime:/etc/localtime:ro
+      - ~/etc/timezone:/etc/localtime:ro
+#      - /etc/localtime:/etc/localtime:ro
     command: '--datadir=~/.ethereum/devchain --rpccorsdomain="*" --networkid=456719 --rpc --bootnodes="enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@XXX:30303"'
   netstats:
     build: eth-netstats
@@ -38,6 +40,7 @@ services:
     environment:
       - WS_SECRET=eth-net-stats-secret
     volumes:
-      - /etc/localtime:/etc/localtime:ro
+      - ~/etc/timezone:/etc/localtime:ro
+#      - /etc/localtime:/etc/localtime:ro
     ports:
       - "3000:3000"

--- a/eth-netstats/Dockerfile
+++ b/eth-netstats/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /eth-netstats
 RUN npm install
 RUN npm install -g grunt-cli
 RUN grunt
-
+RUN sudo mkdir -p ~/etc && touch ~/etc/localtime | /usr/sbin/systemsetup -gettimezone | sed 's/^Time Zone\: //' > ~/etc/localtime
 EXPOSE 3000
 
 CMD ["npm", "start"]

--- a/monitored-geth-client/Dockerfile
+++ b/monitored-geth-client/Dockerfile
@@ -12,4 +12,5 @@ ADD start.sh /root/start.sh
 ADD app.json /root/eth-net-intelligence-api/app.json
 RUN chmod +x /root/start.sh
 
+RUN sudo mkdir -p ~/etc && touch ~/etc/localtime | /usr/sbin/systemsetup -gettimezone | sed 's/^Time Zone\: //' > ~/etc/localtime
 ENTRYPOINT /root/start.sh


### PR DESCRIPTION
Fixes the issue #44  of Mount denied - Path /etc/localtime is not shared from OS X and is not known to Docker.

Similar to docker/for-mac#2396
Solution that worked for me
```
$ mkdir ~/etc
$ vi ~/etc/timezone
```
Enter the timezone (mine was `America/New_York`)

Later updated the `docker-compose.yml` file with the following
```
  - ~/etc/timezone:/etc/localtime:ro
     # - /etc/localtime:/etc/localtime:ro #comment this
```

Hence this pull request.