### PR TITLE
Fix failures in docker-compose.yml that prevented containers to run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     links:
       - netstats
     entrypoint: /root/start.sh
-    command: '--datadir=~/.ethereum/devchain --nodekeyhex=091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --rpcapi "db,personal,eth,net,web3" --rpccorsdomain="*" --networkid=456719 --rpc --rpcaddr="0.0.0.0"'
+    # command: '--datadir=~/.ethereum/devchain --nodekeyhex=091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --http.api "personal,eth,net,web3" --http.corsdomain="*" --networkid=456719 --http --http.addr="0.0.0.0"'
     volumes:
       - ./files/password:/root/files/password:ro
       - ./files/genesis.json:/root/files/genesis.json:ro
@@ -30,7 +30,7 @@ services:
       - ./files/genesis.json:/root/files/genesis.json:ro
       - ./files/keystore:/root/.ethereum/devchain/keystore:rw
       - /etc/localtime:/etc/localtime:ro
-    command: '--datadir=~/.ethereum/devchain --rpccorsdomain="*" --networkid=456719 --rpc --bootnodes="enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@XXX:30303"'
+    command: '--datadir=~/.ethereum/devchain --http.corsdomain="*" --networkid=456719 --http --bootnodes="enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@XXX:30303"'
   netstats:
     build: eth-netstats
     restart: on-failure

--- a/files/genesis.json
+++ b/files/genesis.json
@@ -2,6 +2,7 @@
   "config": {
     "chainId": 456719,
     "homesteadBlock": 0,
+    "eip150Block": 0,
     "eip155Block": 0,
     "eip158Block": 0
   },

--- a/monitored-geth-client/Dockerfile
+++ b/monitored-geth-client/Dockerfile
@@ -1,6 +1,6 @@
 FROM ethereum/client-go
 
-RUN apk add --update git bash nodejs nodejs-npm perl
+RUN apk add --update git bash nodejs npm perl
 
 RUN cd /root &&\
     git clone https://github.com/cubedro/eth-net-intelligence-api &&\

--- a/monitored-geth-client/start.sh
+++ b/monitored-geth-client/start.sh
@@ -2,7 +2,7 @@
 set -e
 cd /root/eth-net-intelligence-api
 perl -pi -e "s/XXX/$(hostname)/g" app.json
-/usr/bin/pm2 start ./app.json
+/usr/local/bin/pm2 start ./app.json
 sleep 3
 geth --datadir=~/.ethereum/devchain init "/root/files/genesis.json"
 sleep 3


### PR DESCRIPTION
Fixed: geth has updated parameters, as well as node js package and location where binary is deployed

Tested running docker-compose and accessing netstat UI.
```
rdcastro-mbp:ethereum-docker rdcastro$ docker-compose ps -a
NAME                    COMMAND                  SERVICE             STATUS              PORTS
bootstrap               "/root/start.sh"         bootstrap           running             0.0.0.0:8545->8545/tcp, 0.0.0.0:30303->30303/tcp, 8546/tcp, 0.0.0.0:30303->30303/udp
ethereum-docker-eth-1   "/root/start.sh --da…"   eth                 running             8545-8546/tcp, 30303/tcp, 30303/udp
netstats                "docker-entrypoint.s…"   netstats            running             0.0.0.0:3000->3000/tcp
```
